### PR TITLE
Now that a simple deploy depends on pyopenssl, it's time to add it to re...

### DIFF
--- a/requirements
+++ b/requirements
@@ -4,3 +4,4 @@ zope.interface
 twisted
 mock
 txsockjs
+pyopenssl


### PR DESCRIPTION
...qs.
