### PR TITLE
some usability tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,73 +30,73 @@ Using pip
 
     pip install hendrix
 
-or for the cutting edge...
 
-    pip install -e git+git@github.com:hangarunderground/hendrix.git@master#egg=hendrix
+###Running the Development Server
 
-###Deployment/Usage
+cd to the directory where your **manage.py** file is located and...
+    
+    hx start --reload
 
-Hendrix leverages the use of custom django management commands. That
-and a little magic makes `hx` available as a shortcut to all of
-the functionality you'd expect from `python manage.py hx`.
+This is roughly the equivalent of running the django devserver.
 
-Note: `hx` needs to know where your project lives so `cd` to where you house
-your Django project.
+see the examples below for more configuration options.
 
-You can but *don't* have to include "hendrix" in your project's INSTALLED_APPS list
-```python
-INSTALLED_APPS = (
-    ...,
-    'hendrix',
-    ...
-)
-```
-But if you really want to run Hendrix using `python manage.py hx [action]` then
-you have to include it.
+--
+###Deployment
 
-###Ubuntu Servers
+
+#####Ubuntu Servers
 If you're running an Ubuntu/Debian server you may want to install
 Hendrix as a service. To do this you can use the helper script `install-hendrix-service`.
 Here's how you do it:
 
-1. If you don't already have a [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
-for you project install one and in that install your project's requirements (which now includes Hendrix):
+1. You'll need to use **virtualenv**. If you don't have that set up, follow [the virtualenv instructions here.](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
+
+2. Paste the example below into a file called **hendrix.conf**
+
+3. Enter the following:
 
     ```bash
-    virtualenv --no-site-packages --distribute /path/to/new/venv
-
-    source /path/to/new/venv/bin/activate
-
-    pip install -r /path/to/myproject/requirements.txt
+    sudo install-hendrix-service hendrix.conf
     ```
-
-2. Create a hendrix.conf file. Don't worry it's yaml (so it's easy). You can
-copy the [example](https://github.com/hangarunderground/hendrix/blob/master/hendrix/utils/example-yaml.conf)
-and save it wherever you want. You could even do something like this if you want:
-
-    ```bash
-    cd /wherever
-
-    wget https://raw.githubusercontent.com/hangarunderground/hendrix/master/hendrix/utils/example-yaml.conf
-    mv example-yaml.conf hendrix.conf
-
-    # open the file in an editor and change the options
-    nano -c hendrix.conf
-    ```
-
-3. Finally, run your own version of the following command:
-
-    ```bash
-    sudo install-hendrix-service /wherever/hendrix.conf
-    ```
-
-Now you have hendrix running as a service on your server. Easy.
+    
+4. Now you have hendrix running as a service on your server. Easy.
 Use the service as you would any other service i.e. `sudo service hendrix start`.
 
-Coming soon/if you want to build one: an [ansible galaxy](https://galaxy.ansible.com/)
-role would be great.
 
-###From the Command Line
+#####Here is an example hendrix.conf.  It is in [Yaml](http://www.yaml.org) format.
+    
+    
+    # path to virtualenv
+    virtualenv: /home/anthony/venvs/hendrix
+    
+    #path to manage.py
+    project_path: /home/anthony/django/myproject
+    
+    #### everything below is optional #####
+    # settings, if you use different ones for production
+    settings: 'dot.path.to.settings'
+    
+    # default 1
+    processes: 1
+    
+    # default 8000
+    http_port: 8000
+    
+    # default false
+    cache: false
+    
+    # default 8080
+    cache_port: 8888
+    
+    # default 4430
+    https_port: 4430
+    
+    # key and cacert are both required if you want to run ssl
+    key: /path/to/my/priv.key
+
+
+##Examples
 The following outlines how to use Hendrix in your day to day life/development.
 
 #####For help and a complete list of the options:
@@ -111,12 +111,12 @@ or
 
     hx start -w 3
 
-#####Stoping that server:
+#####Stopping that server:
 
     hx stop
 
 
-** *Note that stoping a server is dependent on the settings file and http_port
+** *Note that stopping a server is dependent on the settings file and http_port
 used.* **
 
 E.g. Running a server on port 8000 with local_settings.py would yield
@@ -144,29 +144,6 @@ HENDRIX_CHILD_RESOURCES = (
 No other configuration is necessary.  You don't need to add anything to urls.py.
 
 You can also easily create your own custom static or other handlers by adding them to HENDRIX\_CHILD\_RESOURCES.
-
-
-###Running the Development Server
-```
-hx start --reload
-```
-This will reload your server every time a change is made to a python file in
-your project.
-
-#####Using "dev" mode
-You can also use the development mode, which colourfully prints requests.
-```bash
-hx start --dev
-```
-You could also mix it up with other options:
-```
-hx start --dev --reload --w 2
-```
-or
-```
-hx start --settings production_settings --dev
-```
-etcetera...
 
 
 ###SSL

--- a/hendrix/contrib/cache/resource.py
+++ b/hendrix/contrib/cache/resource.py
@@ -281,7 +281,7 @@ class CacheProxyResource(proxy.ReverseProxyResource):
             host = self.host
         else:
             host = "%s:%d" % (self.host, self.port)
-        request.received_headers['host'] = host
+        request.requestHeaders.addRawHeader('host', host)
         request.content.seek(0, 0)
         qs = urlparse.urlparse(request.uri)[4]
         if qs:

--- a/hendrix/contrib/color.py
+++ b/hendrix/contrib/color.py
@@ -21,3 +21,7 @@ class Colors:
     @classmethod
     def green(cls, message):
         cls.end(cls.OKGREEN, message)
+
+    @classmethod
+    def warning(cls, message):
+        cls.end(cls.WARNING, message)

--- a/hendrix/deploy.py
+++ b/hendrix/deploy.py
@@ -154,7 +154,7 @@ class HendrixDeploy(object):
         action = self.action
         fd = self.options['fd']
 
-        if action == 'start':
+        if action.startswith('start'):
             Colors.blue('Ready and Listening...')
             getattr(self, action)(fd)
         elif action == 'restart':
@@ -268,6 +268,9 @@ class HendrixDeploy(object):
                     # OSError is raised when it trys to kill the child processes
                     pass
         os.remove(self.pid)
+
+    def start_reload(self, fd=None):
+        self.start(fd=fd)
 
     def restart(self, fd=None):
         self.stop()

--- a/hendrix/management/commands/hx.py
+++ b/hendrix/management/commands/hx.py
@@ -9,6 +9,7 @@ from .options import HX_OPTION_LIST
 from django.core.management.base import BaseCommand
 
 from hendrix.deploy import HendrixDeploy
+from hendrix.contrib.color import Colors
 
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
@@ -41,11 +42,11 @@ class Reload(FileSystemEventHandler):
         daemonize, self.reload, self.options = cleanOptions(options)
         if not self.reload:
             raise RuntimeError(
-                'Reload should not be run if --reload has no been passed to '
+                'Reload should not be run if --reload has not been passed to '
                 'the command as an option.'
             )
         self.process = subprocess.Popen(
-            ['hx', 'start'] + self.options
+            ['hx', 'start_reload'] + self.options
         )
 
     def on_any_event(self, event):
@@ -54,7 +55,7 @@ class Reload(FileSystemEventHandler):
         ext = path(event.src_path).ext
         if ext == '.py':
             self.process = self.restart()
-            print "Got it!"
+            Colors.warning("detected changes, restarting...")
 
     def restart(self):
         self.process.terminate()

--- a/hendrix/utils/scripts/hx
+++ b/hendrix/utils/scripts/hx
@@ -67,7 +67,8 @@ if __name__ == "__main__":
         else:
             cmd = HendrixCommand()
             cmd.handle(*args, **options)
-            Colors.green('\nHendrix successfully closed.')
+            if not action == 'start_reload':
+                Colors.green('\nHendrix successfully closed.')
     except Exception:
         Colors.red('ERROR: Could not %s hendrix. Try again using the --traceback flag for more information.' % action)
         os._exit(1)


### PR DESCRIPTION
improved dev server behavior, cleaned up readme, fixed twisted deprecation warnings.

Just fixed some little rough edges I found when using hendrix as a devserver.
It was printing:

```
Starting Hendrix...
Starting Hendrix...
Ready and Listening...
```

There was a deprecation warning about modifying received_headers.  I think I implemented the equivalent using the newly suggested method.

```
hendrix/hendrix/contrib/cache/resource.py:284: DeprecationWarning: twisted.web.http.Request.received_headers was deprecated in Twisted 13.2.0: Please use twisted.web.http.Request.requestHeaders instead.
```

And I cleaned up the read me a lot.  I know it's subjective but I found it a little bit scary!
In my opinion, it works better now.  Starts with the TLDR and if you want more info, you can keep scrolling.
