### PR TITLE
upstart config

### DIFF
--- a/hendrix/utils/templates/upstart.conf.j2
+++ b/hendrix/utils/templates/upstart.conf.j2
@@ -1,3 +1,11 @@
+# put this Ubuntu upstart file at /etc/init/{{app_name}}.conf
+#
+# usage:
+#     sudo start {{app_name}}
+#     sudo stop {{app_name}}
+#     sudo restart {{app_name}}
+#
+
 start on static-network-up
 stop on shutdown
 


### PR DESCRIPTION
For more robust production performance on Ubuntu, this very simple upstart config auto restarts hendrix if it goes down.

It also logs the hx console output to /var/log/upstart/{{app_name}}
usage instructions included.
