### PR TITLE
Toxify the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 .project
 .pydevproject
+.tox
 build
 dist
 hendrix.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ notifications:
       - "Build details: %{build_url}"
       - "Result: %{result}"
     use_notice: true
-script: script: tox
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 env:
   - TOXENV=py27
   - TOXENV=pypy
+install:
+  - pip install tox
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
-python:
-  - "2.7"
-install:
-  - pip install -r requirements
-  - pip install -r test-requirements
+env:
+  - TOXENV=py27
+  - TOXENV=pypy
 notifications:
   email:
     recipients:
@@ -18,4 +16,4 @@ notifications:
       - "Build details: %{build_url}"
       - "Result: %{result}"
     use_notice: true
-script: python hendrix/runtests.py
+script: script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, pypy
+
+[testenv]
+commands = {envpython} hendrix/runtests.py
+deps =
+    -rrequirements
+    -rtest-requirements


### PR DESCRIPTION
I wanted to make sure the tests all pass on PyPy since that's what my company runs on. [Tox](http://tox.rtfd.org) is a great way to test multiple Python implementations with a single command, and it automates a lot of the steps needed to get from a fresh git checkout to running the tests locally.

The tests pass on travis with tox: https://travis-ci.org/dmpayton/hendrix/builds/73636059