### PR TITLE
Removes repeated calls to importWSGI

### DIFF
--- a/hendrix/deploy/base.py
+++ b/hendrix/deploy/base.py
@@ -80,7 +80,10 @@ class HendrixDeploy(object):
                 wsgi_dot_path
             )
             os.kill(pid, 15)
-        wsgi = importlib.import_module(wsgi_module)
+        try:
+            wsgi = importlib.import_module(wsgi_module)
+        except ImportError:
+            raise ImportError("The path '%s' does not exist" % wsgi_dot_path)
         return getattr(wsgi, application_name, None)
 
     @classmethod

--- a/hendrix/deploy/base.py
+++ b/hendrix/deploy/base.py
@@ -82,8 +82,9 @@ class HendrixDeploy(object):
             os.kill(pid, 15)
         try:
             wsgi = importlib.import_module(wsgi_module)
-        except ImportError:
-            raise ImportError("The path '%s' does not exist" % wsgi_dot_path)
+        except ImportError, Argument:
+            chalk.red("Unable to Import module '%s'\n" % wsgi_dot_path)
+            raise ImportError, Argument
         return getattr(wsgi, application_name, None)
 
     @classmethod
@@ -174,8 +175,7 @@ class HendrixDeploy(object):
         # args/signals
         if self.options['dev']:
             _args.append('--dev')
-        if self.options['traceback']:
-            _args.append('--traceback')
+
 
         if not self.use_settings:
             _args += ['--wsgi', self.options['wsgi']]

--- a/hendrix/options.py
+++ b/hendrix/options.py
@@ -68,11 +68,6 @@ HX_OPTION_LIST = (
         )
     ),
     make_option(
-        '--traceback',
-        action='store_true',
-        help='Raise on exception'
-    ),
-    make_option(
         '--reload',
         action='store_true',
         dest='reload',

--- a/hendrix/test/test_ux.py
+++ b/hendrix/test/test_ux.py
@@ -3,6 +3,7 @@ import sys
 from . import HendrixTestCase, TEST_SETTINGS
 from hendrix.contrib import SettingsError
 from hendrix.options import options as hx_options
+from hendrix.deploy.base import HendrixDeploy
 from hendrix import ux
 from mock import patch
 
@@ -57,10 +58,8 @@ class TestMain(HendrixTestCase):
 
     def test_wsgi_wrong_path_raises(self):
         wsgi_dot_path = '_this.leads.nowhere.man'
-        options = self.DEFAULTS
-        options.update({'wsgi': wsgi_dot_path})
 
-        self.assertRaises(ImportError, ux.djangoVsWsgi, options)
+        self.assertRaises(ImportError, HendrixDeploy.importWSGI, wsgi_dot_path)
 
     def test_cwd_exposure(self):
         cwd = os.getcwd()

--- a/hendrix/ux.py
+++ b/hendrix/ux.py
@@ -89,11 +89,8 @@ def launch(*args, **options):
             deploy = HendrixDeploy(action, options)
             deploy.run()
         except Exception, e:
-            if options.get('traceback'):
-                tb = sys.exc_info()[2]
-                msg = traceback.format_exc(tb)
-            else:
-                msg = str(e)
+            tb = sys.exc_info()[2]
+            msg = traceback.format_exc(tb)
             chalk.red(msg, pipe=chalk.stderr)
             os._exit(1)
 
@@ -225,13 +222,6 @@ def main():
             if action not in ['start_reload', 'restart']:
                 chalk.eraser()
                 chalk.green('\nHendrix successfully closed.')
-    except Exception, e:
-        msg = (
-            'ERROR: %s\nCould not %s hendrix. Try again using the --traceback '
-            'flag for more information.'
-        )
-        chalk.red(msg % (str(e), action), pipe=chalk.stderr)
-        if options['traceback']:
-            raise
-        else:
-            os._exit(1)
+    except Exception, Argument:
+        print Argument
+        chalk.red('\n Could not %s hendrix.\n' % action, pipe=chalk.stderr)

--- a/hendrix/ux.py
+++ b/hendrix/ux.py
@@ -153,11 +153,6 @@ def djangoVsWsgi(options):
             options['settings'] = user_settings
         elif settings_mod:
             options['settings'] = settings_mod
-    else:
-        try:
-            base.HendrixDeploy.importWSGI(options['wsgi'])
-        except ImportError:
-            raise ImportError("The path '%s' does not exist" % options['wsgi'])
 
     return options
 


### PR DESCRIPTION
Earlier while debugging I found that hx calls HendrixDeploy.importWSGI() twice, and it is called again when HendrixDeploy is initialized. I removed the call from DjangoVSWSGI. And then replaced the ImportError message in HendrixDeploy.importWSGI().

I also found that importWSGI was called twice after the server was stopped. hx now only causes importWSGI once when stopping.