### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -38,5 +38,5 @@ A better first foray into asynchrony is the [crosstown_traffic](crosstown_traffi
 ### Drawbacks to hendrix
 
 * Because hendrix relies on parts of Twisted that are not compatible with Python 3, hendrix is not yet Python 3-ready for many use cases.
-* For many comparable situations - especially the simple synchornous/ blocking scenario, Hendrix likely uses more RAM and CPU than lighter-weight Python web servers such as uWSGI.
+* For many comparable situations - especially the simple synchronous/ blocking scenario, Hendrix likely uses more RAM and CPU than lighter-weight Python web servers such as uWSGI.
 

--- a/hendrix/contrib/cache/resource.py
+++ b/hendrix/contrib/cache/resource.py
@@ -92,7 +92,7 @@ class CacheClient(proxy.ProxyClient):
     def handleResponsePart(self, buffer):
         """
         Sends the content to the browser and keeps a local copy of it.
-        buffer is just a str of the content to be shown, father is the intial
+        buffer is just a str of the content to be shown, father is the initial
         request.
         """
         self.father.write(buffer)

--- a/hendrix/contrib/concurrency/messaging.py
+++ b/hendrix/contrib/concurrency/messaging.py
@@ -60,7 +60,7 @@ class MessageDispatcher(object):
     can leverage to execute the PubSub process.
     N.B. subscribing a client to an address opens that client to all data
         published to that address. As such it useful to think of addresses as
-        channels. To acheive a private channel an obsure address is required.
+        channels. To achieve a private channel an obscure address is required.
     """
 
     def __init__(self, *args, **kwargs):

--- a/hendrix/deploy/base.py
+++ b/hendrix/deploy/base.py
@@ -125,7 +125,7 @@ class HendrixDeploy(object):
     def addServices(self):
         """
         a helper function used in HendrixDeploy.run
-        it instanstiates the HendrixService and adds child services
+        it instantiates the HendrixService and adds child services
         note that these services will also be run on all processes
         """
         self.addHendrix()
@@ -293,7 +293,7 @@ class HendrixDeploy(object):
                 try:
                     os.kill(int(pid), sig)
                 except OSError:
-                    # OSError raised when it trys to kill the child processes
+                    # OSError raised when it tries to kill the child processes
                     pass
         os.remove(self.pid)
         chalk.green('Stopping Hendrix...')
@@ -308,7 +308,7 @@ class HendrixDeploy(object):
 
     def disownService(self, name):
         """
-        disowns a service on hendirix by name
+        disowns a service on hendrix by name
         returns a factory for use in the adoptStreamPort part of setting up
         multiple processes
         """

--- a/hendrix/deploy/cache.py
+++ b/hendrix/deploy/cache.py
@@ -22,7 +22,7 @@ class HendrixDeployCache(HendrixDeploy):
         )
 
     def addLocalCacheService(self):
-        "adds a CacheService to the instatiated HendrixService"
+        "adds a CacheService to the instantiated HendrixService"
         _cache = self.getCacheService()
         _cache.setName('cache_proxy')
         _cache.setServiceParent(self.hendrix)

--- a/hendrix/deploy/tls.py
+++ b/hendrix/deploy/tls.py
@@ -52,14 +52,14 @@ class HendrixDeployTLS(HendrixDeploy):
     def addServices(self):
         """
         a helper function used in HendrixDeploy.run
-        it instanstiates the HendrixService and adds child services
+        it instantiates the HendrixService and adds child services
         note that these services will also be run on all processes
         """
         super(HendrixDeployTLS, self).addServices()
         self.addSSLService()
 
     def addSSLService(self):
-        "adds a SSLService to the instaitated HendrixService"
+        "adds a SSLService to the instantiated HendrixService"
         https_port = self.options['https_port']
         self.tls_service = HendrixTCPServiceWithTLS(https_port, self.hendrix.site, self.key, self.cert,
                                                     self.context_factory, self.context_factory_kwargs, self.options['max_upload_bytes'])


### PR DESCRIPTION
There are small typos in:
- docs/philosophy.md
- hendrix/contrib/cache/resource.py
- hendrix/contrib/concurrency/messaging.py
- hendrix/deploy/base.py
- hendrix/deploy/cache.py
- hendrix/deploy/tls.py

Fixes:
- Should read `instantiates` rather than `instanstiates`.
- Should read `tries` rather than `trys`.
- Should read `synchronous` rather than `synchornous`.
- Should read `obscure` rather than `obsure`.
- Should read `instantiated` rather than `instatiated`.
- Should read `instantiated` rather than `instaitated`.
- Should read `initial` rather than `intial`.
- Should read `hendrix` rather than `hendirix`.
- Should read `achieve` rather than `acheive`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md